### PR TITLE
[AIRFLOW-6794] - Redshift to s3 adding custom query

### DIFF
--- a/airflow/providers/amazon/aws/operators/redshift_to_s3.py
+++ b/airflow/providers/amazon/aws/operators/redshift_to_s3.py
@@ -74,7 +74,7 @@ class RedshiftToS3Transfer(BaseOperator):
     @apply_defaults
     def __init__(  # pylint: disable=too-many-arguments
             self,
-            schema: str, # Schema and table are not required anymore but it will be let for not breaking current workflows
+            schema: str,  # Let required for not breaking current workflows
             table: str,
             s3_bucket: str,
             s3_key: str,
@@ -114,7 +114,7 @@ class RedshiftToS3Transfer(BaseOperator):
         s3_key = '{}/{}_'.format(self.s3_key, self.table) if self.table_as_file_name else self.s3_key
 
         select_query = self.query if self.query else "SELECT * FROM {schema}.{table}"\
-                                                        .format(schema=self.schema, table=self.table)
+            .format(schema=self.schema, table=self.table)
 
         unload_query = """
                     UNLOAD ('{select_query}')


### PR DESCRIPTION

This change is about adding on redishift_to_s3 operetor an option of it run a custom query not only the default "SELECT * FROM" which was hardcoded there.

The behavior will be if the parameter query was given then it will be use, otherwise the default behavior will be used.

With this change "schema" and "table" will not be required anymore but I didn't change it because I didn't want to change the parameters order to avoid breaking current workflows.

I updated the documentation which is writen as a comment in the class, is there the correct place to update the documetnation?

---
Issue link: WILL BE INSERTED BY [AIRFLOW-6794](https://issues.apache.org/jira/browse/AIRFLOW-6794)

Make sure to mark the boxes below before creating PR: [x]

- [X ] Description above provides context of the change
- [ X] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [X] Unit tests coverage for changes (not needed for documentation changes)
- [X] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [X ] Relevant documentation is updated including usage instructions.
- [X ] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
